### PR TITLE
Correlation Id Support added

### DIFF
--- a/src/OneBeyond.Studio.EmailProviders.AzureCommService.Tests/Program.cs
+++ b/src/OneBeyond.Studio.EmailProviders.AzureCommService.Tests/Program.cs
@@ -36,10 +36,10 @@ using (var serviceScope = serviceProvider.CreateScope())
 {
     var emailSender = serviceScope.ServiceProvider.GetRequiredService<IEmailSender>();
 
-    await SendPlainTextEmailAsync(emailSender);
-    await SendHtmlEmailAsync(emailSender);
-    await SendForcedToEmailAsync(emailSender);
-    await SendAttachmentsEmailAsync(emailSender);
+    var correlationId1 = await SendPlainTextEmailAsync(emailSender);
+    var correlationId2 = await SendHtmlEmailAsync(emailSender);
+    var correlationId3 = await SendForcedToEmailAsync(emailSender);
+    var correlationId4 = await SendAttachmentsEmailAsync(emailSender);
     await SendMultipleEmailsAsync(emailSender);
 }
 
@@ -57,7 +57,7 @@ static async Task SendMultipleEmailsAsync(IEmailSender emailSender, Cancellation
     }
 }
 
-static async Task SendPlainTextEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
+static Task<string?> SendPlainTextEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
 {
     var mail = new MailMessage(_defaultFromEmail, _defaultToEmail)
     {
@@ -66,10 +66,10 @@ static async Task SendPlainTextEmailAsync(IEmailSender emailSender, Cancellation
         IsBodyHtml = true
     };
 
-    await emailSender.SendEmailAsync(mail, ct);
+    return emailSender.SendEmailAsync(mail, ct);
 }
 
-static async Task SendHtmlEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
+static Task<string?> SendHtmlEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
 {
     var mail = new MailMessage(_defaultFromEmail, _defaultToEmail)
     {
@@ -78,10 +78,10 @@ static async Task SendHtmlEmailAsync(IEmailSender emailSender, CancellationToken
         IsBodyHtml = true
     };
 
-    await emailSender.SendEmailAsync(mail, ct);
+    return emailSender.SendEmailAsync(mail, ct);
 }
 
-static async Task SendForcedToEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
+static Task<string?> SendForcedToEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
 {
     var mail = new MailMessage(_defaultFromEmail, "unknown.address@nowhere.com")
     {
@@ -90,10 +90,10 @@ static async Task SendForcedToEmailAsync(IEmailSender emailSender, CancellationT
         IsBodyHtml = true
     };
 
-    await emailSender.SendEmailAsync(mail, ct);
+    return emailSender.SendEmailAsync(mail, ct);
 }
 
-static async Task SendAttachmentsEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
+static Task<string?> SendAttachmentsEmailAsync(IEmailSender emailSender, CancellationToken ct = default)
 {
     var mail = new MailMessage(_defaultFromEmail, _defaultToEmail)
     {
@@ -104,5 +104,5 @@ static async Task SendAttachmentsEmailAsync(IEmailSender emailSender, Cancellati
 
     mail.Attachments.Add(new Attachment("Attachments/attachment.png", "image/png"));
 
-    await emailSender.SendEmailAsync(mail, ct);
+    return emailSender.SendEmailAsync(mail, ct);
 }

--- a/src/OneBeyond.Studio.EmailProviders.AzureCommService.Tests/appsettings.json
+++ b/src/OneBeyond.Studio.EmailProviders.AzureCommService.Tests/appsettings.json
@@ -4,7 +4,8 @@
       "CommunicationServiceConnectionString": "<ADD-CONNECTION-STRING-FROM-COMM-SERVICES>",
       "FromEmailAddress": "<ADD-MAIL-FROM-ASDDRESS-FROM-COMM-SERVICES>",
       "UseEnforcedToEmailAddress": false,
-      "EnforcedToEmailAddress": "andrii.kaplanovskyi@one-beyond.com"
+      "EnforcedToEmailAddress": "andrii.kaplanovskyi@one-beyond.com",
+      "DoNotWaitTillOperationCompleted": true
     }
   }
 }

--- a/src/OneBeyond.Studio.EmailProviders.AzureCommService/OneBeyond.Studio.EmailProviders.AzureCommService/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.EmailProviders.AzureCommService/OneBeyond.Studio.EmailProviders.AzureCommService/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,9 +1,7 @@
-using System;
 using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
-using OneBeyond.Studio.EmailProviders.Domain;
 using OneBeyond.Studio.EmailProviders.AzureCommService.Options;
-using Microsoft.Extensions.Logging;
+using OneBeyond.Studio.EmailProviders.Domain;
 
 namespace OneBeyond.Studio.EmailProviders.AzureCommService.DependencyInjection;
 
@@ -15,13 +13,13 @@ public static class ServiceCollectionExtensions
         EnsureArg.IsNotNull(emailSenderOptions, nameof(emailSenderOptions));
 
         @this.AddSingleton(
-            (serviceProvider) =>
+            (_) =>
             {
                 return new EmailSender(
-                        serviceProvider.GetRequiredService<ILoggerFactory>(),
                         emailSenderOptions.CommunicationServiceConnectionString,
                         emailSenderOptions.FromEmailAddress!,
-                        emailSenderOptions.UseEnforcedToEmailAddress ? emailSenderOptions.EnforcedToEmailAddress : null) as IEmailSender;
+                        emailSenderOptions.UseEnforcedToEmailAddress ? emailSenderOptions.EnforcedToEmailAddress : null,
+                        emailSenderOptions.DoNotWaitTillOperationCompleted) as IEmailSender;
             });
         return @this;
     }

--- a/src/OneBeyond.Studio.EmailProviders.AzureCommService/OneBeyond.Studio.EmailProviders.AzureCommService/Options/EmailSenderOptions.cs
+++ b/src/OneBeyond.Studio.EmailProviders.AzureCommService/OneBeyond.Studio.EmailProviders.AzureCommService/Options/EmailSenderOptions.cs
@@ -9,4 +9,9 @@ public sealed record EmailSenderOptions : Domain.Options.EmailSenderOptions
     /// Azure communication service connection string
     /// </summary>
     public string CommunicationServiceConnectionString { get; init; } = default!;
+    /// <summary>
+    /// When DoNotWaitTillOperationCompleted is true, we just pass the e-mail to communication services and do not wait till the e-mail is acutally sent.
+    /// When DoNotWaitTillOperationCompleted is false, we do wait till the e-mail is acutally sent (takes longer).
+    /// </summary>
+    public bool DoNotWaitTillOperationCompleted { get; init; }
 }

--- a/src/OneBeyond.Studio.EmailProviders.Domain/IEmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Domain/IEmailSender.cs
@@ -7,12 +7,12 @@ namespace OneBeyond.Studio.EmailProviders.Domain;
 public interface IEmailSender
 {
     /// <summary>
-    /// Email sender
+    /// Send e-mail
     /// </summary>
-    /// <param name="mailMessage"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task SendEmailAsync(
+    /// <param name="mailMessage">E-mail to be sent</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Correlation Id of the e-mail in the external system</returns>
+    Task<string?> SendEmailAsync(
         MailMessage mailMessage,
         CancellationToken cancellationToken = default);
 }

--- a/src/OneBeyond.Studio.EmailProviders.Exchange/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Exchange/EmailSender.cs
@@ -22,15 +22,16 @@ internal sealed class EmailSender : IEmailSender
     private readonly string? _saveCopyFolderId;
 
     /// <summary>Create an object to Handle Sending e-mail using Exchange service</summary>
-    public EmailSender(ExchangeVersion exchangeVersion,
-                            string username,
-                            string password,
-                            string webServiceUrl,
-                            string fromEmail,
-                            string fromEmailName,
-                            string? enforcedToEmailAddress,
-                            bool saveCopy,
-                            string? saveCopyFolderId)
+    public EmailSender(
+        ExchangeVersion exchangeVersion,
+        string username,
+        string password,
+        string webServiceUrl,
+        string fromEmail,
+        string fromEmailName,
+        string? enforcedToEmailAddress,
+        bool saveCopy,
+        string? saveCopyFolderId)
     {
 
         EnsureArg.IsNotNull<ExchangeVersion>(exchangeVersion);

--- a/src/OneBeyond.Studio.EmailProviders.Folder/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Folder/EmailSender.cs
@@ -28,12 +28,11 @@ internal sealed class EmailSender : IEmailSender
         _enforcedToEmailAddress = enforcedToEmailAddress;
     }
 
-    public Task SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken)
+    public async Task<string?> SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(mailMessage, nameof(mailMessage));
 
-        if (mailMessage.From is null
-            && _fromEmailAddress is { })
+        if (mailMessage.From is null && _fromEmailAddress is { })
         {
             mailMessage.From = new MailAddress(_fromEmailAddress, _fromEmailName ?? _fromEmailAddress);
         }
@@ -46,6 +45,10 @@ internal sealed class EmailSender : IEmailSender
 
         var mimeMessage = (MimeMessage)mailMessage;
 
-        return mimeMessage.WriteToAsync($"{_folder}/{Guid.NewGuid()}.eml", cancellationToken);
+        var correlationId = Guid.NewGuid().ToString();
+
+        await mimeMessage.WriteToAsync($"{_folder}/{correlationId}.eml", cancellationToken);
+
+        return correlationId;
     }
 }

--- a/src/OneBeyond.Studio.EmailProviders.Graph/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Graph/EmailSender.cs
@@ -59,8 +59,6 @@ internal sealed class EmailSender : IEmailSender
     {
         EnsureArg.IsNotNull(mailMessage, nameof(mailMessage));
 
-        var correlationId = Guid.NewGuid().ToString();
-
         var message = new Message
         {
             Subject = mailMessage.Subject,
@@ -74,11 +72,7 @@ internal sealed class EmailSender : IEmailSender
             ToRecipients = GetRecipientsList(mailMessage.To),
             BccRecipients = GetRecipientsList(mailMessage.Bcc),
             CcRecipients = GetRecipientsList(mailMessage.CC),
-            Attachments = GetAttachmentsList(mailMessage.Attachments),
-            AdditionalData = new Dictionary<string, object>
-                {
-                    {"X-Correlation-Id", correlationId}
-                }
+            Attachments = GetAttachmentsList(mailMessage.Attachments)
         };
 
         try
@@ -94,7 +88,7 @@ internal sealed class EmailSender : IEmailSender
                     }, 
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            return correlationId;
+            return null; // We do not support correlation Id for this Email Sender
         }
         catch (Exception exception)
         {

--- a/src/OneBeyond.Studio.EmailProviders.Graph/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Graph/EmailSender.cs
@@ -85,7 +85,7 @@ internal sealed class EmailSender : IEmailSender
                     new SendMailPostRequestBody 
                     { 
                         Message = message, 
-                        SaveToSentItems = false 
+                        SaveToSentItems = false
                     }, 
                     cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/src/OneBeyond.Studio.EmailProviders.Graph/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Graph/EmailSender.cs
@@ -54,7 +54,7 @@ internal sealed class EmailSender : IEmailSender
 
     //Note! If you use this provider, please make sure the application registration you're using
     //has the API Permission (Type: Application) to Microsoft Graph : Mail.Send
-    public async Task SendEmailAsync(
+    public async Task<string?> SendEmailAsync(
         MailMessage mailMessage,
         CancellationToken cancellationToken = default)
     {

--- a/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
@@ -26,18 +26,19 @@ internal sealed class EmailSender : IEmailSender
     private readonly bool _enableSsl;
 
     /// <summary>Create an object to Handle Sending e-mail using Office365 service</summary>
-    public EmailSender(ExchangeVersion exchangeVersion,
-                            string username,
-                            string password,
-                            string fromEmail,
-                            string fromEmailName,
-                            string? enforcedToEmailAddress,
-                            string deliveryMethod,
-                            bool saveCopy,
-                            string? saveCopyFolderId,
-                            int port,
-                            string host,
-                            bool enableSsl)
+    public EmailSender(
+        ExchangeVersion exchangeVersion,
+        string username,
+        string password,
+        string fromEmail,
+        string fromEmailName,
+        string? enforcedToEmailAddress,
+        string deliveryMethod,
+        bool saveCopy,
+        string? saveCopyFolderId,
+        int port,
+        string host,
+        bool enableSsl)
     {
         EnsureArg.IsNotNullOrWhiteSpace(username, nameof(username));
         EnsureArg.IsNotNullOrWhiteSpace(password, nameof(password));
@@ -79,7 +80,7 @@ internal sealed class EmailSender : IEmailSender
 
         if (_deliveryMethod == DeliveryMethod.Smtp)
         {
-            return SendMailMessageAsync(mailMessage);
+            return SendMailMessageAsync(mailMessage, cancellationToken);
         }
 
         if (_deliveryMethod == DeliveryMethod.EWS)
@@ -162,7 +163,7 @@ internal sealed class EmailSender : IEmailSender
         return SendMailMessageAsync(emailMessage);
     }
 
-    private async System.Threading.Tasks.Task<string?> SendMailMessageAsync(MailMessage mailMessage)
+    private async System.Threading.Tasks.Task<string?> SendMailMessageAsync(MailMessage mailMessage, CancellationToken cancellationToken)
     {
         using (var smtpClient = new SmtpClient()
         {
@@ -172,7 +173,7 @@ internal sealed class EmailSender : IEmailSender
             EnableSsl = _enableSsl
         })
         {
-            await smtpClient.SendMailAsync(mailMessage);
+            await smtpClient.SendMailAsync(mailMessage, cancellationToken);
         }
 
         return null; //We do not support correlation Id for SmtpClient

--- a/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
@@ -39,8 +39,6 @@ internal sealed class EmailSender : IEmailSender
                             string host,
                             bool enableSsl)
     {
-
-
         EnsureArg.IsNotNullOrWhiteSpace(username, nameof(username));
         EnsureArg.IsNotNullOrWhiteSpace(password, nameof(password));
         EnsureArg.IsNotNullOrWhiteSpace(fromEmail, nameof(fromEmail));
@@ -69,7 +67,7 @@ internal sealed class EmailSender : IEmailSender
         _enableSsl = enableSsl;
     }
 
-    public System.Threading.Tasks.Task SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken = default)
+    public System.Threading.Tasks.Task<string?> SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(mailMessage);
 
@@ -84,12 +82,15 @@ internal sealed class EmailSender : IEmailSender
             return SendMailMessageAsync(mailMessage);
         }
 
-        return _deliveryMethod == DeliveryMethod.EWS
-            ? SendEWSMailMessageAsync(mailMessage)
-            : throw new EmailSenderException($"Delivery Method '{_deliveryMethod}' is not supported.");
+        if (_deliveryMethod == DeliveryMethod.EWS)
+        {
+            return SendEWSMailMessageAsync(mailMessage);
+        }
+
+        throw new EmailSenderException($"Delivery Method '{_deliveryMethod}' is not supported.");
     }
 
-    private System.Threading.Tasks.Task SendEWSMailMessageAsync(MailMessage mailMessage)
+    private System.Threading.Tasks.Task<string?> SendEWSMailMessageAsync(MailMessage mailMessage)
     {
         if (mailMessage.AlternateViews.Count > 0)
         {
@@ -161,26 +162,38 @@ internal sealed class EmailSender : IEmailSender
         return SendMailMessageAsync(emailMessage);
     }
 
-    private System.Threading.Tasks.Task SendMailMessageAsync(MailMessage mailMessage)
+    private async System.Threading.Tasks.Task<string?> SendMailMessageAsync(MailMessage mailMessage)
     {
-        using (var smtpClient = new SmtpClient())
+        using (var smtpClient = new SmtpClient()
         {
-            smtpClient.Credentials = new NetworkCredential(_username, _password);
-            smtpClient.Port = _port;
-            smtpClient.Host = _host;
-            smtpClient.EnableSsl = _enableSsl;
-            return smtpClient.SendMailAsync(mailMessage);
+            Credentials = new NetworkCredential(_username, _password),
+            Port = _port,
+            Host = _host, 
+            EnableSsl = _enableSsl
+        })
+        {
+            await smtpClient.SendMailAsync(mailMessage);
         }
+
+        return null; //We do not support correlation Id for SmtpClient
     }
 
-    private System.Threading.Tasks.Task SendMailMessageAsync(EmailMessage emailMessage)
+    private async System.Threading.Tasks.Task<string?> SendMailMessageAsync(EmailMessage emailMessage)
     {
-        return _saveCopy
-            ? !string.IsNullOrWhiteSpace(_saveCopyFolderId)
-                ? emailMessage.SendAndSaveCopy(new FolderId(_saveCopyFolderId))
-                : emailMessage.SendAndSaveCopy()
-            : emailMessage.Send();
+        if (_saveCopy)
+        {
+            var folderId = !string.IsNullOrWhiteSpace(_saveCopyFolderId)
+                ? new FolderId(_saveCopyFolderId)
+                : new FolderId(WellKnownFolderName.SentItems);
 
+            await emailMessage.SendAndSaveCopy(folderId);
+        }
+        else
+        {
+            await emailMessage.Send();
+        }
+
+        return null; //We do not support correlation Id for this email sender
     }
 
     private EmailMessage CreateExchangeEmail()

--- a/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
@@ -75,7 +75,7 @@ internal sealed class EmailSender : IEmailSender, IDisposable
         }
     }
 
-    public async Task SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken)
+    public async Task<string?> SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(mailMessage);
 
@@ -118,6 +118,8 @@ internal sealed class EmailSender : IEmailSender, IDisposable
         {
             await ReleaseSmtpClientAsync(smtpClient, cancellationToken).ConfigureAwait(false);
         }
+
+        return null; //We do not support correlation Id for SMTP senders
     }
 
     private async Task<(int Id, MailKit.Net.Smtp.SmtpClient Value)> AcquireSmtpClientAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Correlation Id Support added to SendGrid and AzureCommService email senders. 

IEmailSender interface: SendEmailAsync now returns the correlation id, which can be used to track an e-mail in external systems (like in SendGrid on in Azure Communication service)

AzureCommService Emails provider: an extra configuration option DoNotWaitTillOperationCompleted is added:
- When DoNotWaitTillOperationCompleted is true, we just pass the e-mail to communication services and do not wait till the e-mail is acutally sent.
- When DoNotWaitTillOperationCompleted is false, we do wait till the e-mail is acutally sent (takes longer).

No breaking changes.