### PR TITLE
Feature/comma separated enforced emails

### DIFF
--- a/src/OneBeyond.Studio.EmailProviders.AzureCommService/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.AzureCommService/EmailSender.cs
@@ -53,7 +53,7 @@ internal sealed class EmailSender : IEmailSender
         }
         else
         {
-            emailRecipients= new EmailRecipients(toAddressesList);
+            emailRecipients = new EmailRecipients(toAddressesList);
         }
         
         var emailContent = new EmailContent(mailMessage.Subject);

--- a/src/OneBeyond.Studio.EmailProviders.Domain/Options/EmailSenderOptions.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Domain/Options/EmailSenderOptions.cs
@@ -18,8 +18,9 @@ public abstract record EmailSenderOptions
     public bool UseEnforcedToEmailAddress { get; init; }
 
     /// <summary>
-    /// Specificies the email address to send all the emails to, overriding user email.
+    /// Specifies the email addresses to send all the emails to, overriding user email.
     /// <remarks>This setting is used only if <see cref="UseEnforcedToEmailAddress"/> is true</remarks>
+    /// <remarks>This setting now supports a comma delimited list of emails.</remarks>
     /// </summary>
     public string? EnforcedToEmailAddress { get; init; }
 }

--- a/src/OneBeyond.Studio.EmailProviders.Exchange/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Exchange/EmailSender.cs
@@ -17,7 +17,7 @@ internal sealed class EmailSender : IEmailSender
     private readonly string _webServiceUrl;
     private readonly string _fromEmail;
     private readonly string _fromEmailName;
-    private readonly string? _enforcedToEmailAddress;
+    private readonly string? _enforcedToEmailAddresses;
     private readonly bool _saveCopy;
     private readonly string? _saveCopyFolderId;
 
@@ -29,7 +29,7 @@ internal sealed class EmailSender : IEmailSender
         string webServiceUrl,
         string fromEmail,
         string fromEmailName,
-        string? enforcedToEmailAddress,
+        string? enforcedToEmailAddresses,
         bool saveCopy,
         string? saveCopyFolderId)
     {
@@ -51,7 +51,7 @@ internal sealed class EmailSender : IEmailSender
         _webServiceUrl = webServiceUrl;
         _fromEmail = fromEmail;
         _fromEmailName = fromEmailName;
-        _enforcedToEmailAddress = enforcedToEmailAddress;
+        _enforcedToEmailAddresses = enforcedToEmailAddresses;
         _saveCopy = saveCopy;
         _saveCopyFolderId = saveCopyFolderId;
     }
@@ -65,10 +65,11 @@ internal sealed class EmailSender : IEmailSender
             throw new EmailSenderException("AlternativeViews are not supported by Exchange (EWS).");
         }
 
-        if (!string.IsNullOrEmpty(_enforcedToEmailAddress))
+        if (!string.IsNullOrEmpty(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
-            mailMessage.To.Add(new MailAddress(_enforcedToEmailAddress));
+            // Exchange handles inserting a comma-separated string.
+            mailMessage.To.Add(_enforcedToEmailAddresses);
         }
 
         //map Net MailMessage to EWS EmailMessage

--- a/src/OneBeyond.Studio.EmailProviders.Folder/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Folder/EmailSender.cs
@@ -13,19 +13,19 @@ internal sealed class EmailSender : IEmailSender
     private readonly string _folder;
     private readonly string? _fromEmailAddress;
     private readonly string? _fromEmailName;
-    private readonly string? _enforcedToEmailAddress;
+    private readonly string? _enforcedToEmailAddresses;
 
     public EmailSender(
         string folder,
         string? fromEmailAddress,
         string? fromEmailName,
-        string? enforcedToEmailAddress)
+        string? enforcedToEmailAddresses)
     {
         EnsureArg.IsNotNullOrWhiteSpace(folder, nameof(folder));
         _folder = folder;
         _fromEmailAddress = fromEmailAddress;
         _fromEmailName = fromEmailName;
-        _enforcedToEmailAddress = enforcedToEmailAddress;
+        _enforcedToEmailAddresses = enforcedToEmailAddresses;
     }
 
     public async Task<string?> SendEmailAsync(MailMessage mailMessage, CancellationToken cancellationToken)
@@ -37,10 +37,11 @@ internal sealed class EmailSender : IEmailSender
             mailMessage.From = new MailAddress(_fromEmailAddress, _fromEmailName ?? _fromEmailAddress);
         }
 
-        if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddress))
+        if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
-            mailMessage.To.Add(new MailAddress(_enforcedToEmailAddress));
+            // Folder sending allows comma-separated string
+            mailMessage.To.Add(_enforcedToEmailAddresses);
         }
 
         var mimeMessage = (MimeMessage)mailMessage;

--- a/src/OneBeyond.Studio.EmailProviders.Graph/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Graph/DependencyInjection/ServiceCollectionExtensions.cs
@@ -29,7 +29,8 @@ public static class ServiceCollectionExtensions
                     emailSenderOptions.ClientId!,
                     emailSenderOptions.TenantId!,
                     emailSenderOptions.Secret!,
-                    emailSenderOptions.SenderUserAzureId!
+                    emailSenderOptions.SenderUserAzureId!,
+                    emailSenderOptions.UseEnforcedToEmailAddress ? emailSenderOptions.EnforcedToEmailAddress : null
                     ) as IEmailSender;
             });
         return @this;

--- a/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
@@ -17,7 +17,7 @@ internal sealed class EmailSender : IEmailSender
     private readonly string _password;
     private readonly string _fromEmail;
     private readonly string _fromEmailName;
-    private readonly string? _enforcedToEmailAddress;
+    private readonly string? _enforcedToEmailAddresses;
     private readonly string _deliveryMethod;
     private readonly bool _saveCopy;
     private readonly string? _saveCopyFolderId;
@@ -32,7 +32,7 @@ internal sealed class EmailSender : IEmailSender
         string password,
         string fromEmail,
         string fromEmailName,
-        string? enforcedToEmailAddress,
+        string? enforcedToEmailAddresses,
         string deliveryMethod,
         bool saveCopy,
         string? saveCopyFolderId,
@@ -59,7 +59,7 @@ internal sealed class EmailSender : IEmailSender
         _password = password;
         _fromEmail = fromEmail;
         _fromEmailName = fromEmailName;
-        _enforcedToEmailAddress = enforcedToEmailAddress;
+        _enforcedToEmailAddresses = enforcedToEmailAddresses;
         _deliveryMethod = deliveryMethod;
         _saveCopy = saveCopy;
         _saveCopyFolderId = saveCopyFolderId;
@@ -72,10 +72,11 @@ internal sealed class EmailSender : IEmailSender
     {
         EnsureArg.IsNotNull(mailMessage);
 
-        if (!string.IsNullOrEmpty(_enforcedToEmailAddress))
+        if (!string.IsNullOrEmpty(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
-            mailMessage.To.Add(new MailAddress(_enforcedToEmailAddress));
+            // Office365 handles comma separated email list
+            mailMessage.To.Add(_enforcedToEmailAddresses);
         }
 
         if (_deliveryMethod == DeliveryMethod.Smtp)

--- a/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
@@ -24,7 +24,7 @@ internal sealed class EmailSender : IEmailSender, IDisposable
     private readonly string? _password;
     private readonly string? _fromEmailAddress;
     private readonly string? _fromEmailName;
-    private readonly string? _enforcedToEmailAddress;
+    private readonly string? _enforcedToEmailAddresses;
     private readonly ConcurrentQueue<(int Id, MailKit.Net.Smtp.SmtpClient Value)> _smtpClients;
     private int _lastSmtpClientId;
     private readonly bool _enableProtocolLogging;
@@ -38,7 +38,7 @@ internal sealed class EmailSender : IEmailSender, IDisposable
         string? password,
         string? fromEmailAddress,
         string? fromEmailName,
-        string? enforcedToEmailAddress,
+        string? enforcedToEmailAddresses,
         bool enableProtocolLogging)
     {
         EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
@@ -60,7 +60,7 @@ internal sealed class EmailSender : IEmailSender, IDisposable
         _password = password;
         _fromEmailAddress = fromEmailAddress;
         _fromEmailName = fromEmailName;
-        _enforcedToEmailAddress = enforcedToEmailAddress;
+        _enforcedToEmailAddresses = enforcedToEmailAddresses;
         _smtpClients = new ConcurrentQueue<(int Id, MailKit.Net.Smtp.SmtpClient Value)>();
         _lastSmtpClientId = 0;
         _enableProtocolLogging = enableProtocolLogging;
@@ -85,10 +85,11 @@ internal sealed class EmailSender : IEmailSender, IDisposable
             mailMessage.From = new MailAddress(_fromEmailAddress, _fromEmailName ?? _fromEmailAddress);
         }
 
-        if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddress))
+        if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
-            mailMessage.To.Add(new MailAddress(_enforcedToEmailAddress));
+            // SMTP handles comma-separated string.
+            mailMessage.To.Add(_enforcedToEmailAddresses);
         }
 
         var mimeMessage = (MimeMessage)mailMessage;


### PR DESCRIPTION
This feature has already been approved. We just forgot to press the merge button...

https://dev.azure.com/dcslsoftwareltd/DCSL%20Tooling/_git/Waterloo%20Email%20Providers/pullrequest/46195

There is also now a need for this in Hudson, and given it's mostly done, this should be fine.

