### PR TITLE
fix: CC and BCC should not be bypasses to operation

### DIFF
--- a/src/OneBeyond.Studio.EmailProviders.Exchange/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Exchange/EmailSender.cs
@@ -68,6 +68,9 @@ internal sealed class EmailSender : IEmailSender
         if (!string.IsNullOrEmpty(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
+            mailMessage.CC.Clear();
+            mailMessage.Bcc.Clear();
+            
             // Exchange handles inserting a comma-separated string.
             mailMessage.To.Add(_enforcedToEmailAddresses);
         }

--- a/src/OneBeyond.Studio.EmailProviders.Folder/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Folder/EmailSender.cs
@@ -40,6 +40,8 @@ internal sealed class EmailSender : IEmailSender
         if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
+            mailMessage.CC.Clear();
+            mailMessage.Bcc.Clear();
             // Folder sending allows comma-separated string
             mailMessage.To.Add(_enforcedToEmailAddresses);
         }

--- a/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Office365/EmailSender.cs
@@ -75,6 +75,8 @@ internal sealed class EmailSender : IEmailSender
         if (!string.IsNullOrEmpty(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
+            mailMessage.CC.Clear();
+            mailMessage.Bcc.Clear();
             // Office365 handles comma separated email list
             mailMessage.To.Add(_enforcedToEmailAddresses);
         }

--- a/src/OneBeyond.Studio.EmailProviders.SendGrid/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.SendGrid/EmailSender.cs
@@ -61,7 +61,7 @@ internal sealed class EmailSender : IEmailSender
             sendGridMessage.AddTo(to);
         }
 
-        if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddresses))
+        if (string.IsNullOrWhiteSpace(_enforcedToEmailAddresses))
         {
             foreach (var cc in mailMessage.CC)
             {

--- a/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
@@ -88,6 +88,9 @@ internal sealed class EmailSender : IEmailSender, IDisposable
         if (!string.IsNullOrWhiteSpace(_enforcedToEmailAddresses))
         {
             mailMessage.To.Clear();
+            mailMessage.CC.Clear();
+            mailMessage.Bcc.Clear();
+
             // SMTP handles comma-separated string.
             mailMessage.To.Add(_enforcedToEmailAddresses);
         }


### PR DESCRIPTION
Currently, you can use CC and BCC to bypass the email redirection process.

Also it causes a bug in SendGrid, where if you include a CC to someone in your enforced list, it doesn't take it into account.

