### PR TITLE
Ensure SmtpClient is disconnected after sending the email

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -44,7 +44,7 @@ jobs:
           --logger "trx;logfileprefix=tr"
 
       - name: "Publish Solution Test Results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: "test-results"

--- a/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
+++ b/src/OneBeyond.Studio.EmailProviders.Smtp/EmailSender.cs
@@ -114,7 +114,6 @@ internal sealed class EmailSender : IEmailSender, IDisposable
                 exception,
                 "Unable to send message via SmptClient {SmtpClientId}. Disconnecting the client before releasing it",
                 smtpClient.Id);
-            await smtpClient.Value.DisconnectAsync(true, cancellationToken).ConfigureAwait(false);
 
             throw new EmailSenderException("Unable to send message via SmptClient { SmtpClientId }.Disconnecting the client before releasing it.", exception);
         }
@@ -173,12 +172,13 @@ internal sealed class EmailSender : IEmailSender, IDisposable
         (int Id, MailKit.Net.Smtp.SmtpClient Value) smtpClient,
         CancellationToken cancellationToken)
     {
+        await smtpClient.Value.DisconnectAsync(true, cancellationToken).ConfigureAwait(false);
+
         // Only SmtpClients created before threshold are returned into the queue for later re-use,
         // all the others get decommissioned. Another option that SmtpClient gets returned regardless its id
         // provided the queue count is less than the threshold.
         if (smtpClient.Id > SmtpClientsMaxCount)
         {
-            await smtpClient.Value.DisconnectAsync(true, cancellationToken).ConfigureAwait(false);
             smtpClient.Value.Dispose();
         }
         else


### PR DESCRIPTION
Ensure the `SmtpClient` is successfully disconnected after sending an email via Smtp.

## Description
Currently when an email is sent via Smtp, the `SmtpClient` used in the operation is not disconnected. Instead, it remains active to be used later. 
This causes issues because SMTP servers often automatically close idle connections after a set period of time (a few minutes). So if the period of inactivity is long enough, i.e. 10 minutes, the `SmtpClient` may fail to send the next email.

Ensuring the `SmtpClient` is disconnected after the email is sent prevents this issue from happening, so the ideal flow every time an email needs to be sent would be:
```
smtpClient.ConnectAsync();
smtpClient.SendEmailAsync();
smtpClient.DisconnectAsync();
```
